### PR TITLE
Add resource detection processor

### DIFF
--- a/ocb-config.yaml
+++ b/ocb-config.yaml
@@ -31,6 +31,7 @@ exporters:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.71.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter v0.71.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter v0.71.0
+  
 
 extensions:
   - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.71.0
@@ -48,6 +49,7 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.71.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.71.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.71.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetector v0.71.0
 
 replaces:
 - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter => github.com/dbason/opentelemetry-collector-contrib/exporter/opensearchexporter v0.0.0-20230306003502-9c6c4f5280f7


### PR DESCRIPTION
When we collect host metrics from each agent collector, we are collecting host metrics for either the virtual or physical host the node is on. 

Currently, [host metrics receiver does not have any configurations for identifying the hosts](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/4524ffcac423dcd6743f012e3b24808e6346a7cd/receiver/hostmetricsreceiver/README.md?plain=1#L174) , so we should include the resource detection processor, so the aggregator can differentiate the host-metrics received from different nodes, instead of de duping them to a single metric