### PR TITLE
generate binaries using goreleaser

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -1,0 +1,31 @@
+name: goreleaser
+
+on:
+  push:
+    # run only against tags
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v4
+        with:
+          go-version: stable
+      # More assembly might be required: Docker logins, GPG, etc. It all depends
+      # on your needs.
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/
 otelcol-custom
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,53 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+# same builds as opentelemetry-collector releases
+builds:
+    - id: otelcol-custom
+      goos:
+        - darwin
+        - linux
+        - windows
+      goarch:
+        - "386"
+        - amd64
+        - arm64
+        - ppc64le
+      ignore:
+        - goos: darwin
+          goarch: "386"
+        - goos: windows
+          goarch: arm64
+      dir: distributions/otelcol/_build
+      binary: otelcol-custom
+      ldflags:
+        - -s
+        - -w
+      flags:
+        - -trimpath
+      env:
+        - CGO_ENABLED=0
+# same archives as opentelemetry-collector releases
+archives:
+    - id: otelcol-custom
+      builds:
+        - otelcol-custom
+      name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+
+# The lines beneath this are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj


### PR DESCRIPTION
Use `goreleaser` tool so we can have access to our open telemetry collector binary for local development.

`goreleaser` also has some convenient docker release publishing settings we could look into