### PR TITLE
Add prometheus receiver & exporter data directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ COPY . .
 
 RUN CGO_ENABLED=0 builder --config=ocb-config.yaml
 RUN chmod +x otelcol-custom
+RUN mkdir -p prometheus/wal
+RUN mkdir -p prometheus/certs
 
 FROM alpine:latest as prep
 RUN apk --update add ca-certificates
@@ -60,6 +62,8 @@ COPY --from=journal /etc/passwd /etc/passwd
 
 COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /otel/otelcol-custom /
+COPY --from=builder /otel/prometheus/wal /
+COPY --from=builder /otel/prometheus/certs /
 
 USER scratchuser
 


### PR DESCRIPTION
- `/etc/otel/prometheus/certs` exists as a target for secrets discovered by the operator to be mounted. The secret discovery matches Prometheus operator. See https://github.com/rancher/opni/pull/1334.

- `/etc/otel/prometheus/wal` exists as a target for a WAL in case remote-writing fails (our remote-write is tied to agent uptime, so data will be lost if an agent receives a patch for example)